### PR TITLE
Fix create API numeric validation

### DIFF
--- a/src/pages/api/create.ts
+++ b/src/pages/api/create.ts
@@ -22,11 +22,17 @@ export default async function createTVorMovie(
   const { apiId, mediaType, title, status, season, episode, poster } = req.body
 
   // If is not number
-  !Number(apiId) && res.status(400).send('apiId must be number')
+  if (!Number(apiId)) {
+    return res.status(400).send('apiId must be number')
+  }
 
   if (mediaType === 'tv') {
-    !Number(season) && res.status(400).send('season must be number')
-    !Number(episode) && res.status(400).send('episode must be number')
+    if (!Number(season)) {
+      return res.status(400).send('season must be number')
+    }
+    if (!Number(episode)) {
+      return res.status(400).send('episode must be number')
+    }
 
     const tvApiId = apiId
     // Check if tv show exists


### PR DESCRIPTION
## Summary
- ensure numeric fields in `create` API return on validation error

## Testing
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile)*
- `yarn build` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6848cb10f4d08331b567ebb61dd2d4d7